### PR TITLE
[Test] Add destination-patterns-to-preserve input

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-RUN apk add --no-cache git openssh-client
+RUN apk add --no-cache git openssh-client bash rsync
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,10 @@ inputs:
     description: '[Optional] The directory to wipe and replace in the target repository'
     default: ''
     required: false
+  destination-patterns-to-preserve:
+    description: "[Optional] Paths to preserve in destination"
+    default: ''
+    required: false
         
 runs:
   using: docker
@@ -64,6 +68,7 @@ runs:
     - '${{ inputs.target-branch }}'
     - '${{ inputs.commit-message }}'
     - '${{ inputs.target-directory }}'
+    - '${{ inputs.destination-patterns-to-preserve }}'
 branding:
   icon: git-commit
   color: green

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -l
+#!/bin/bash -l
 
 set -e  # if a command fails it stops the execution
 set -u  # script fails if trying to access to an undefined variable
@@ -15,6 +15,7 @@ DESTINATION_REPOSITORY_USERNAME="${8}"
 TARGET_BRANCH="${9}"
 COMMIT_MESSAGE="${10}"
 TARGET_DIRECTORY="${11}"
+DESTINATION_PATTERNS_TO_PRESERVE="${12}"
 
 if [ -z "$DESTINATION_REPOSITORY_USERNAME" ]
 then
@@ -83,6 +84,16 @@ TEMP_DIR=$(mktemp -d)
 # including "." and with the exception of ".git/"
 mv "$CLONE_DIR/.git" "$TEMP_DIR/.git"
 
+if [ -n "$DESTINATION_PATTERNS_TO_PRESERVE"]
+then
+	DESTINATION_PATTERNS_TO_PRESERVE_ARRAY=($DESTINATION_PATTERNS_TO_PRESERVE)
+	# NOTE(brad): The business inside ${...} is just prepending $CLONE_DIR/./ to every
+	# item in DESTINATION_PATTERNS_TO_PRESERVE_ARRAY. The /./ tells rsync to copy only the
+	# directory structure that comes after it (i.e., to not copy over the $CLONE_DIR portion
+	# of the path).
+	rsync -r --links ${DESTINATION_PATTERNS_TO_PRESERVE_ARRAY[@]/#/$CLONE_DIR/./} "$TEMP_DIR"
+fi
+
 # $TARGET_DIRECTORY is '' by default
 ABSOLUTE_TARGET_DIRECTORY="$CLONE_DIR/$TARGET_DIRECTORY/"
 
@@ -98,7 +109,9 @@ ls -al
 echo "[+] Listing root Location"
 ls -al /
 
-mv "$TEMP_DIR/.git" "$CLONE_DIR/.git"
+# NOTE(brad): This doesn't really need to perform a copy, but rsync made it easier to
+# make the moving process robust, so I used rsync anyway.
+rsync -r --links $TEMP_DIR/ "$CLONE_DIR"
 
 echo "[+] List contents of $SOURCE_DIRECTORY"
 ls "$SOURCE_DIRECTORY"


### PR DESCRIPTION
This action currently completely wipes clean the repository it is
pushing to (with the exception of the root .git file) to ensure that
files not in the source directory are actually deleted from the pushed
to repository.

This is desirable behavior in general, but I'd like to be able to
specifically preserve certain files.

To that end, I've added an optional destination-patterns-to-preserve
argument which allows you to specify patterns to identify files and
directories in the destination repository to preserve.

The arguments need to be passed in as a string with the seperate
patterns seperated by a space character (this is because it looks like
github actions forces all inputs to be strings, bools, and numbers;
would have prefered to use a yaml list if I could).

Internally, this uses rsync to copy over matching files and directories
in the source directory to the same temp directory already used to
preserve the root .git, and then uses rsync to copy them back. I mostly
used rsync because it's pretty flexible and made it easier to specify
which files I want moved and which I don't. Also useful for handling
symbolic links (explicitly) and files starting with '.' (both of which
are relevant to my use case).

I changed the script used to `/bin/bash` from `/bin/sh` because some of
the extra features bash has made were useful for prepending absolute
paths to the relative patterns the user supplies.